### PR TITLE
Fix alignment not applying with auto-headers; Add option to control header separator padding

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -180,20 +180,17 @@ final class Column
     /**
      * Creates the column header separator string.
      *
+     * @param bool $ignoreHeaderPadding We do not want padding for header separator if true.
      * @return string The column header separator string.
      */
-    public function createHeaderSeparator(): string
+    public function createHeaderSeparator(bool $ignoreHeaderPadding = false): string
     {
+        $padding = $ignoreHeaderPadding ? 2 : 0;
+
         return match ($this->alignment) {
-            self::ALIGN_RIGHT => sprintf(
-                '%s:',
-                str_repeat('-', $this->length - 1),
-            ),
-            self::ALIGN_CENTER => sprintf(
-                ':%s:',
-                str_repeat('-', $this->length - 2),
-            ),
-            default => str_repeat('-', $this->length),
+            self::ALIGN_RIGHT => str_repeat('-', $this->length - 1 + $padding) . ':',
+            self::ALIGN_CENTER => ':' . str_repeat('-', $this->length - 2 + $padding) . ':',
+            default => str_repeat('-', $this->length + $padding),
         };
     }
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -41,6 +41,11 @@ final class Table
     private $stringLengthCallback = null;
 
     /**
+     * @var array<array-key, string>|string|null Stored alignment configuration for auto-headers
+     */
+    private string | array | null $pendingAlignments = null;
+
+    /**
      * Table constructor.
      * It is possible to define the columns using an array like this:
      * ['first', 'next', 'last']
@@ -195,6 +200,13 @@ final class Table
      */
     public function setAlignment(array | string $align): Table
     {
+        if ($this->options['autoHeaders'] && !$this->hasColumns()) {
+            // store alignments to apply after columns are created
+            $this->pendingAlignments = $align;
+
+            return $this;
+        }
+
         if (is_array($align)) {
             // apply different alignment for each column
             $colKeys = array_keys($this->columns);
@@ -235,6 +247,12 @@ final class Table
             }
             // remove the header row from data rows
             array_shift($rows);
+
+            // apply any pending alignments after columns are created
+            if ($this->pendingAlignments !== null) {
+                $this->setAlignment($this->pendingAlignments);
+                $this->pendingAlignments = null;
+            }
         }
 
         if (!$this->hasColumns()) {

--- a/tests/CoreTableTest.php
+++ b/tests/CoreTableTest.php
@@ -12,7 +12,11 @@ class CoreTableTest extends TestCase
 {
     public function testSimpleTable(): void
     {
-        $t = new Table(options: ['delimiterStart' => false, 'delimiterEnd' => false]);
+        $t = new Table(options: [
+            'delimiterStart' => false,
+            'delimiterEnd' => false,
+            'headerSeparatorPadding' => true,
+        ]);
         $t->addColumn(0, new Column('Col.A'));
 
         $this->assertInstanceOf(Column::class, $t->getColumn(0));
@@ -32,7 +36,10 @@ class CoreTableTest extends TestCase
 
     public function testConstructorWithColumns(): void
     {
-        $t = new Table(['first_name', 'last_name'], ['delimiterStart' => false, 'delimiterEnd' => false]);
+        $t = new Table(
+            ['first_name', 'last_name'],
+            ['delimiterStart' => false, 'delimiterEnd' => false, 'headerSeparatorPadding' => true],
+        );
 
         $expect = 'first_name | last_name   ' . PHP_EOL
             . '---------- | ------------' . PHP_EOL
@@ -52,7 +59,10 @@ class CoreTableTest extends TestCase
      */
     public function testDroppingColumn(): void
     {
-        $t = new Table(['first_name', 'last_name'], ['delimiterStart' => false, 'delimiterEnd' => false]);
+        $t = new Table(
+            ['first_name', 'last_name'],
+            ['delimiterStart' => false, 'delimiterEnd' => false, 'headerSeparatorPadding' => true],
+        );
 
         $expect = 'last_name   ' . PHP_EOL
             . '------------' . PHP_EOL
@@ -74,7 +84,10 @@ class CoreTableTest extends TestCase
      */
     public function testChangeColumnTitle(): void
     {
-        $t = new Table(['first_name', 'last_name'], ['delimiterStart' => false, 'delimiterEnd' => false]);
+        $t = new Table(
+            ['first_name', 'last_name'],
+            ['delimiterStart' => false, 'delimiterEnd' => false, 'headerSeparatorPadding' => true],
+        );
 
         $expect = 'first_name | surname     ' . PHP_EOL
             . '---------- | ------------' . PHP_EOL

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\sabat24\MarkdownTable;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use sabat24\MarkdownTable\Column;
 use sabat24\MarkdownTable\Table;
 use PHPUnit\Framework\TestCase;
@@ -12,7 +13,7 @@ class TableTest extends TestCase
 {
     public function testSimpleTable(): void
     {
-        $t = new Table();
+        $t = new Table(options: ['headerSeparatorPadding' => true]);
         $t->addColumn(0, new Column('Col.A'));
 
         $this->assertInstanceOf(Column::class, $t->getColumn(0));
@@ -32,7 +33,7 @@ class TableTest extends TestCase
 
     public function testTableWithAutoHeaders(): void
     {
-        $t = new Table(options: ['autoHeaders' => true]);
+        $t = new Table(options: ['autoHeaders' => true, 'headerSeparatorPadding' => true]);
 
         $expect = '| Col.A | Col.B | Col.C |' . PHP_EOL
             . '| ----- | ----- | ----- |' . PHP_EOL
@@ -48,9 +49,127 @@ class TableTest extends TestCase
         ]));
     }
 
+    /**
+     * Data provider for testTablePaddings
+     *
+     * @return array<string, array{options: array<string, bool>, alignment: string, expected: string}>
+     */
+    public static function tableOptionsProvider(): array
+    {
+        return [
+            'no padding, left alignment' => [
+                'options' => [
+                    'padding' => false,
+                    'headerSeparatorPadding' => false,
+                    'delimiterStart' => true,
+                    'delimiterEnd' => true,
+                ],
+                'alignment' => 'l',
+                'expected' => '|Col.A|Col.B|Col.C|' . PHP_EOL
+                    . '|-----|-----|-----|' . PHP_EOL
+                    . '|a    |z    |     |' . PHP_EOL
+                    . '|b    |     |     |' . PHP_EOL
+                    . '|c    |y    |x    |' . PHP_EOL,
+            ],
+            'with padding, left alignment' => [
+                'options' => [
+                    'padding' => true,
+                    'headerSeparatorPadding' => true,
+                    'delimiterStart' => true,
+                    'delimiterEnd' => true,
+                ],
+                'alignment' => 'l',
+                'expected' => '| Col.A | Col.B | Col.C |' . PHP_EOL
+                    . '| ----- | ----- | ----- |' . PHP_EOL
+                    . '| a     | z     |       |' . PHP_EOL
+                    . '| b     |       |       |' . PHP_EOL
+                    . '| c     | y     | x     |' . PHP_EOL,
+            ],
+            'with padding, no delimiters, left alignment' => [
+                'options' => [
+                    'padding' => true,
+                    'headerSeparatorPadding' => true,
+                    'delimiterStart' => false,
+                    'delimiterEnd' => false,
+                ],
+                'alignment' => 'l',
+                'expected' => 'Col.A | Col.B | Col.C' . PHP_EOL
+                    . '----- | ----- | -----' . PHP_EOL
+                    . 'a     | z     |      ' . PHP_EOL
+                    . 'b     |       |      ' . PHP_EOL
+                    . 'c     | y     | x    ' . PHP_EOL,
+            ],
+            'with padding except header separator, left alignment' => [
+                'options' => [
+                    'padding' => true,
+                    'headerSeparatorPadding' => false,
+                    'delimiterStart' => true,
+                    'delimiterEnd' => true,
+                ],
+                'alignment' => 'l',
+                'expected' => '| Col.A | Col.B | Col.C |' . PHP_EOL
+                    . '|-------|-------|-------|' . PHP_EOL
+                    . '| a     | z     |       |' . PHP_EOL
+                    . '| b     |       |       |' . PHP_EOL
+                    . '| c     | y     | x     |' . PHP_EOL,
+            ],
+            'no padding, right alignment' => [
+                'options' => [
+                    'padding' => false,
+                    'headerSeparatorPadding' => false,
+                    'delimiterStart' => true,
+                    'delimiterEnd' => true,
+                ],
+                'alignment' => 'r',
+                'expected' => '|Col.A|Col.B|Col.C|' . PHP_EOL
+                    . '|----:|----:|----:|' . PHP_EOL
+                    . '|    a|    z|     |' . PHP_EOL
+                    . '|    b|     |     |' . PHP_EOL
+                    . '|    c|    y|    x|' . PHP_EOL,
+            ],
+            'no padding, center alignment' => [
+                'options' => [
+                    'padding' => false,
+                    'headerSeparatorPadding' => false,
+                    'delimiterStart' => true,
+                    'delimiterEnd' => true,
+                ],
+                'alignment' => 'c',
+                'expected' => '|Col.A|Col.B|Col.C|' . PHP_EOL
+                    . '|:---:|:---:|:---:|' . PHP_EOL
+                    . '|  a  |  z  |     |' . PHP_EOL
+                    . '|  b  |     |     |' . PHP_EOL
+                    . '|  c  |  y  |  x  |' . PHP_EOL,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, bool> $options
+     * @param string $alignment
+     * @param string $expected
+     */
+    #[DataProvider('tableOptionsProvider')] public function testTablePaddings(
+        array $options,
+        string $alignment,
+        string $expected,
+    ): void {
+        $t = new Table(options: ['autoHeaders' => true, 'headerSeparatorPadding' => true]);
+
+        $t->setOptions($options);
+        $t->setAlignment($alignment);
+
+        $this->assertEquals($expected, $t->getString([
+            ['Col.A', 'Col.B', 'Col.C'],
+            ['a', 'z'],
+            ['b'],
+            ['c', 'y', 'x'],
+        ]));
+    }
+
     public function testTableAssociativeNonExistingWithAutoHeaders(): void
     {
-        $t = new Table(options: ['autoHeaders' => true]);
+        $t = new Table(options: ['autoHeaders' => true, 'headerSeparatorPadding' => true]);
 
         $expect = '| Col.A | Col.B | Col.C |' . PHP_EOL
             . '| ----- | ----- | ----- |' . PHP_EOL


### PR DESCRIPTION
Stores alignment settings when columns don't exist yet and applies them after auto-headers create the columns.

Add new 'headerSeparatorPadding' option to control whether padding spaces should be included in the header separator row.