### PR TITLE
Add column position handling flexibility in Table constructor

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -51,14 +51,15 @@ final class Table
      * It is possible to define the columns using an array like this:
      * ['first', 'next', 'last']
      *
-     * @param array<int|string, string> $keys Optional an array of column names. Default: []
-     * @param array{alignDelimiters?: bool, delimiterStart?: bool, delimiterEnd?: bool, padding?: bool, autoHeaders?: bool, headerSeparatorPadding?: bool} $options Optional configuration options. Default: []
+     * @param array<int|string, string> $columnNames Optional an array of column names. Default: []
+     * @param array{ alignDelimiters?: bool, delimiterStart?: bool, delimiterEnd?: bool, padding?: bool, autoHeaders?: bool, headerSeparatorPadding?: bool } $options Optional configuration options. Default: []
+     * @param bool $useNamesAsPositions Controls how column positions and names are handled. When this parameter is true, the column name is used as the position identifier instead of using the array key. Default: false
      */
-    public function __construct(array $keys = [], array $options = [])
+    public function __construct(array $columnNames = [], array $options = [], bool $useNamesAsPositions = false)
     {
         $this->clearColumns();
-        foreach ($keys as $key) {
-            $this->addColumn($key, new Column($key));
+        foreach ($columnNames as $position => $columnName) {
+            $this->addColumn($useNamesAsPositions ? $columnName : $position, new Column($columnName));
         }
 
         $this->options = array_merge($this->options, $options);

--- a/tests/CoreTableTest.php
+++ b/tests/CoreTableTest.php
@@ -16,7 +16,8 @@ class CoreTableTest extends TestCase
             'delimiterStart' => false,
             'delimiterEnd' => false,
             'headerSeparatorPadding' => true,
-        ]);
+        ], useNamesAsPositions: true);
+
         $t->addColumn(0, new Column('Col.A'));
 
         $this->assertInstanceOf(Column::class, $t->getColumn(0));
@@ -39,6 +40,7 @@ class CoreTableTest extends TestCase
         $t = new Table(
             ['first_name', 'last_name'],
             ['delimiterStart' => false, 'delimiterEnd' => false, 'headerSeparatorPadding' => true],
+            true,
         );
 
         $expect = 'first_name | last_name   ' . PHP_EOL
@@ -62,6 +64,7 @@ class CoreTableTest extends TestCase
         $t = new Table(
             ['first_name', 'last_name'],
             ['delimiterStart' => false, 'delimiterEnd' => false, 'headerSeparatorPadding' => true],
+            true,
         );
 
         $expect = 'last_name   ' . PHP_EOL
@@ -87,6 +90,7 @@ class CoreTableTest extends TestCase
         $t = new Table(
             ['first_name', 'last_name'],
             ['delimiterStart' => false, 'delimiterEnd' => false, 'headerSeparatorPadding' => true],
+            true,
         );
 
         $expect = 'first_name | surname     ' . PHP_EOL
@@ -109,7 +113,7 @@ class CoreTableTest extends TestCase
      */
     public function testExceptionNonExistentColumnPosition(): void
     {
-        $t = new Table(['first_name']);
+        $t = new Table(['first_name'], [], true);
         self::expectException(\RuntimeException::class);
         self::expectExceptionMessage('Column position last_name does not exist!');
         $t->getColumn('last_name');
@@ -131,7 +135,7 @@ class CoreTableTest extends TestCase
      */
     public function testExceptionWithOneDimensionalArray(): void
     {
-        $t = new Table(['first_name', 'last_name']);
+        $t = new Table(['first_name', 'last_name'], [], true);
         self::expectException(\RuntimeException::class);
         self::expectExceptionMessage('Rows need to be an array of arrays.');
         /**

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -31,6 +31,21 @@ class TableTest extends TestCase
         ]));
     }
 
+    public function testTableWithColumnsConstructor(): void
+    {
+        $t = new Table(['Branch', 'Commit']);
+
+        $expect = '| Branch  | Commit           |' . PHP_EOL
+            . '|---------|------------------|' . PHP_EOL
+            . '| main    | 0123456789abcdef |' . PHP_EOL
+            . '| staging | fedcba9876543210 |' . PHP_EOL;
+
+        $this->assertEquals($expect, $t->getString([
+            ['main', '0123456789abcdef'],
+            ['staging', 'fedcba9876543210'],
+        ]));
+    }
+
     public function testTableWithAutoHeaders(): void
     {
         $t = new Table(options: ['autoHeaders' => true, 'headerSeparatorPadding' => true]);


### PR DESCRIPTION
Add `useNamesAsPositions` parameter to Table constructor to control how column positions are determined.